### PR TITLE
Remove AWS SDK dependency since `instanceof` is unreliable.

### DIFF
--- a/example/glob.js
+++ b/example/glob.js
@@ -3,13 +3,11 @@
 'use strict';
 
 var path = require('path'),
-	S3 = require('aws-sdk').S3,
+	AWS = require('aws-sdk'),
 	S3GlobStream = require(path.join(__dirname, '..')),
 	argv = require('yargs').argv;
 
-var s3 = new S3();
-
-var stream = S3GlobStream(s3, { Bucket: argv.bucket }, argv._);
+var stream = S3GlobStream(new AWS.S3(), { Bucket: argv.bucket }, argv._);
 
 stream.on('readable', function readable() {
 	var entry;

--- a/lib/glob.js
+++ b/lib/glob.js
@@ -3,7 +3,6 @@
 
 var _ = require('lodash'),
 	Stream = require('stream'),
-	S3 = require('aws-sdk').S3,
 	Minimatch = require('minimatch').Minimatch,
 	util = require('util');
 
@@ -20,8 +19,8 @@ function GlobStream(s3, awsOptions, globs, streamOptions) {
 		return new GlobStream(s3, awsOptions, globs, streamOptions);
 	}
 
-	// Type check
-	if (s3 instanceof S3 === false) {
+	// Duck typing
+	if (!s3 || !_.isFunction(s3.listObjects)) {
 		throw new TypeError();
 	}
 

--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
 	},
 	"dependencies": {
 		"lodash": "*",
-		"aws-sdk": "*",
 		"minimatch": "*"
+	},
+	"peerDependencies": {
+		"aws-sdk": "*"
 	},
 	"devDependencies": {
 		"eslint": "*",

--- a/test/spec/glob.js
+++ b/test/spec/glob.js
@@ -2,7 +2,6 @@
 'use strict';
 
 var _ = require('lodash'),
-	AWS = require('aws-sdk'),
 	Minimatch = require('minimatch').Minimatch,
 	GlobStream = require('glob');
 
@@ -11,7 +10,7 @@ describe('GlobStream', function() {
 
 		beforeEach(function() {
 			this.sandbox = sinon.sandbox.create();
-			this.s3 = sinon.createStubInstance(AWS.S3);
+			this.s3 = { listObjects: this.sandbox.stub() };
 			this.sandbox.stub(GlobStream.prototype, '_read');
 		});
 
@@ -100,8 +99,7 @@ describe('GlobStream', function() {
 
 		beforeEach(function() {
 			this.sandbox = sinon.sandbox.create();
-			this.s3 = sinon.createStubInstance(AWS.S3);
-			this.s3.listObjects = sinon.stub();
+			this.s3 = { listObjects: this.sandbox.stub() };
 			this.stream = GlobStream(this.s3, { Bucket: 'test' }, [ '*', '!b' ]);
 		});
 


### PR DESCRIPTION
When two different versions of the SDK are installed and required node marks them as different, so instead just duck type it. This also conveniently makes testing a little easier too.
