### PR TITLE
Refactor to use S3 URLs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
+sudo: false
 language: node_js
 node_js:
-- '0.11'
+- '0.12'
 - '0.10'
+- 'iojs-1'
+before_install:
+- npm install -g "npm@>=1.4.6"
 after_success:
 - npm install coveralls
 - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # s3-glob
 
-> Retrieve object list entries in S3 using minimatch-style globbing.
+Retrieve object list entries in S3 using minimatch-style globbing.
 
 ![build status](http://img.shields.io/travis/izaakschroeder/s3-glob.svg?style=flat)
 ![coverage](http://img.shields.io/coveralls/izaakschroeder/s3-glob.svg?style=flat)
@@ -10,14 +10,14 @@
 
 
 Features:
- * Full support for minimatch syntax,
- * Streaming output.
+ * Full support for minimatch-style syntax,
+ * Streaming output,
+ * Ready for piping into S3.getObject or S3.headObject.
 
 ```javascript
-var S3 = require('aws-sdk').S3,
-	GlobStream = require('s3-glob');
+var GlobStream = require('s3-glob');
 
-var stream = GlobStream(new S3(), { Bucket: 'my-bucket' }, [ '*.jpg', '!test*' ]);
+var stream = new GlobStream([ 's3://my-bucket/*.jpg', '!test*' ]);
 
 stream.on('readable', function() {
 	var entry;
@@ -25,4 +25,11 @@ stream.on('readable', function() {
 		console.log(entry);
 	}
 });
+```
+
+```javascript
+var GlobStream = require('s3-glob');
+
+var stream = GlobStream([ 's3://my-bucket/*.jpg' ], { format: 'query' });
+//...
 ```

--- a/example/glob.js
+++ b/example/glob.js
@@ -3,11 +3,12 @@
 'use strict';
 
 var path = require('path'),
-	AWS = require('aws-sdk'),
 	S3GlobStream = require(path.join(__dirname, '..')),
 	argv = require('yargs').argv;
 
-var stream = S3GlobStream(new AWS.S3(), { Bucket: argv.bucket }, argv._);
+console.log(argv._);
+
+var stream = S3GlobStream(argv._);
 
 stream.on('readable', function readable() {
 	var entry;

--- a/lib/glob.js
+++ b/lib/glob.js
@@ -2,35 +2,45 @@
 'use strict';
 
 var _ = require('lodash'),
+	AWS = require('aws-sdk'),
 	Stream = require('stream'),
 	Minimatch = require('minimatch').Minimatch,
+	url = require('s3-url'),
 	util = require('util');
 
 /**
  * @constructor
- * @param {AWS.S3} s3 S3 instance.
- * @param {Object} awsOptions Parameters passed straight to `listObjects`.
- * @param {Array|String} globs List of glob patterns to match.
- * @param {Object} streamOptions Options passed to Stream.Readable.
+ * @param {Array|String|Object} globs List of glob patterns to match.
+ * @param {Object} options Options.
+ * @param {Boolean} options.format Output object format.
+ * @param {Object} options.s3 S3 instance to use.
+ *
+ * Note that the globs are either S3 URLs of the form s3://bucket/key/*...
+ * or negation patterns of the form !not/pattern. Globbing is done in a similar
+ * manner to file-glob, where anything matching ANY of the positive patterns is
+ * returned (only once) but nothing matching ANY of the negative patterns is.
  */
-function GlobStream(s3, awsOptions, globs, streamOptions) {
+function GlobStream(globs, options) {
+
 	// Allow not using `new`
 	if (this instanceof GlobStream === false) {
-		return new GlobStream(s3, awsOptions, globs, streamOptions);
+		return new GlobStream(globs, options);
 	}
+
+	options = _.assign({
+		highWaterMark: 200,
+		format: 'object',
+		unique: true,
+		s3: new AWS.S3()
+	}, options);
 
 	// Duck typing
-	if (!s3 || !_.isFunction(s3.listObjects)) {
-		throw new TypeError();
-	}
-
-	// Must provide a bucket.
-	if (!_.has(awsOptions, 'Bucket')) {
-		throw new TypeError();
+	if (!options.s3 || !_.isFunction(options.s3.listObjects)) {
+		throw new TypeError('Bad S3.');
 	}
 
 	// Handle the single value case
-	if (_.isString(globs)) {
+	if (_.isString(globs) || _.isPlainObject(globs)) {
 		globs = [ globs ];
 	}
 
@@ -39,30 +49,145 @@ function GlobStream(s3, awsOptions, globs, streamOptions) {
 		throw new TypeError();
 	}
 
-	// Create the readable with some sensible defaults.
-	Stream.Readable.call(this, _.assign({
-		highWaterMark: 200
-	}, streamOptions, { objectMode: true }));
-
-	this.s3 = s3;
-	this.awsOptions = awsOptions;
-
-	// Create the globs
-	this.globs = _.map(globs, Minimatch);
-
-	// Must have at least 1 non-negative glob
-	if (_.every(this.globs, 'negate')) {
+	if (!_.contains(GlobStream.formats, options.format)) {
 		throw new TypeError();
 	}
 
-	this.states = _.map(GlobStream.prefixes(globs), function buildState(prefix) {
-		return {
-			Prefix: prefix,
-			Marker: null
-		};
+	// Create the readable with some sensible defaults.
+	Stream.Readable.call(this, {
+		objectMode: true,
+		highWaterMark: options.highWaterMark
 	});
+
+	this.s3 = options.s3;
+	this.awsOptions = options.awsOptions;
+	this.unique = options.unique;
+	this.format = options.format;
+
+
+	var parts = _.groupBy(globs, function group(glob) {
+		if (_.isString(glob) && glob.charAt(0) === '!') {
+			return 'filter';
+		} else {
+			return 'search';
+		}
+	});
+
+	this.filters = _.map(parts.filter, Minimatch);
+
+	this.states = _.chain(parts.search)
+		.map(this.normalize, this)
+		.map(function state(awsOptions) {
+			var match = Minimatch(awsOptions.Key);
+			return _.map(GlobStream.prefixes(match), function entry(prefix) {
+				return {
+					match: match,
+					awsOptions: awsOptions,
+					prefix: prefix,
+					marker: null
+				};
+			});
+		})
+		.flatten()
+		.value();
+
+	this.processed = { };
+
+	// Must have at least 1 non-negative glob
+	if (this.states.length === 0) {
+		throw new TypeError('Must have at least 1 non-negative glob.');
+	}
 }
 util.inherits(GlobStream, Stream.Readable);
+
+GlobStream.formats = [
+	'object',
+	'query'
+];
+
+GlobStream.allowedOptions = [
+	'Bucket'
+];
+
+/**
+ * Create and validate AWS parameters from a globbish object.
+ * @param {String|Object} glob Thing to suck parameters out of.
+ * @returns {Object} AWS parameters.
+ */
+GlobStream.prototype.normalize = function normalize(glob) {
+	var res = _.assign(
+		{ },
+		this.awsOptions,
+		_.isString(glob) ? url.urlToOptions(glob) : glob
+	);
+
+	if (_.isEmpty(res.Key)) {
+		throw new TypeError();
+	} else if (_.isEmpty(res.Bucket)) {
+		throw new TypeError();
+	} else {
+		return res;
+	}
+};
+
+/**
+ * Determine if the entry matches the current search. All negative filters
+ * of the stream must be matched and the local entry's filter must be matched.
+ * @param {Object} search One of the entries in this.states.
+ * @param {Object} entry The AWS object gotten from the AWS SDK.
+ * @returns {Boolean} True if we should add this to the stream.
+ */
+GlobStream.prototype.match = function match(search, entry) {
+	return _.every(this.filters, function check(filter) {
+		return filter.match(entry.Key);
+	}) && search.match.match(entry.Key);
+};
+
+/**
+ * Return a unique key for S3 objects. This is used to check and see if the
+ * entry has already been processed.
+ * @param {Object} search One of the entries in this.states.
+ * @param {Object} entry The AWS object gotten from the AWS SDK.
+ * @returns {String} A unique key for `entry`.
+ */
+GlobStream.prototype.key = function key(search, entry) {
+	return entry.Bucket + '/' + entry.Key;
+};
+
+/**
+ * Check if an S3 object has been processed or not.
+ * @param {Object} search One of the entries in this.states.
+ * @param {Object} entry The AWS object gotten from the AWS SDK.
+ * @returns {Boolean} True if processed, false otherwise.
+ */
+GlobStream.prototype.hasProcessed = function hasProcessed(search, entry) {
+	return this.processed[this.key(search, entry)];
+};
+
+/**
+ * Process an AWS object retrived from S3.listObjects.
+ * @param {Object} search One of the entries in this.states.
+ * @param {Object} entry The AWS object gotten from the AWS SDK.
+ * @returns {void}
+ */
+GlobStream.prototype.process = function process(search, entry) {
+	if (this.unique && this.hasProcessed(search, entry)) {
+		return;
+	}
+	this.processed[this.key(search, entry)] = true;
+	if (this.match(search, entry)) {
+		switch (this.format) {
+		case 'query':
+			this.push(_.assign({ }, search.awsOptions, { Key: entry.Key }));
+			break;
+		case 'object':
+			this.push(entry);
+			break;
+		default:
+			this.emit('error', 'UNKNOWN_FORMAT');
+		}
+	}
+};
 
 /**
  * @param {Array} set Single match set from a Minimatch object.
@@ -70,28 +195,17 @@ util.inherits(GlobStream, Stream.Readable);
  */
 GlobStream.prefix = function prefix(set) {
 	return _.chain(set)
-		.first(_.isString)
+		.takeWhile(_.isString)
 		.join('/')
 		.value();
 };
 
 /**
- * @param {Array} globs List of Minimatch glob items.
- * @returns {Array} List of prefixes.
- */
-GlobStream.prefixes = function prefixes(globs) {
-	return _.chain(globs)
-		.reject('negate')
-		.pluck('set')
-		.flatten(true)
-		.map(GlobStream.prefix)
-		.value();
-};
-
-GlobStream.prototype.match = function match(entry) {
-	return _.every(this.globs, function checkGlob(glob) {
-		return glob.match(entry.Key);
-	});
+* @param {Object} match Single Minimatch object.
+* @returns {Array} Array of prefixes corresponding to the Minimatch object.
+*/
+GlobStream.prefixes = function prefix(match) {
+	return _.map(match.set, GlobStream.prefix);
 };
 
 /**
@@ -122,11 +236,15 @@ GlobStream.prototype._read = function _read(size) {
 
 	self._reading = true;
 
+	var request = _.defaults({ }, {
+		Prefix: state.prefix,
+		Marker: state.marker,
+		MaxKeys: size
+	}, _.pick(state.awsOptions, GlobStream.allowedOptions));
+
 	// Fetch the objects making sure to respect the desired
 	// highWaterMark (passed in through size here).
-	self.s3.listObjects(_.assign({ }, self.awsOptions, state, {
-		MaxKeys: size
-	}), function listObjectsDone(err, result) {
+	self.s3.listObjects(request, function listObjectsDone(err, result) {
 
 		// Pass thru errors
 		if (err) {
@@ -134,9 +252,10 @@ GlobStream.prototype._read = function _read(size) {
 		}
 
 		// Pump all the matching results out to the stream
-		_.chain(result.Contents)
-			.filter(self.match, self)
-			.each(self.push, self);
+		_.forEach(result.Contents, function process(entry) {
+			entry.Bucket = request.Bucket;
+			self.process(state, entry);
+		});
 
 		// Unlock for more reads
 		self._reading = false;
@@ -149,7 +268,7 @@ GlobStream.prototype._read = function _read(size) {
 			// The NextMarker is only provided when Delimiter is set, otherwise
 			// the Key of the last element is to be used instead (as per the
 			// AWS documentation).
-			state.Marker = result.NextMarker || _.last(result.Contents).Key;
+			state.marker = result.NextMarker || _.last(result.Contents).Key;
 		} else {
 			self.states.pop();
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "s3-glob",
-	"version": "0.1.1",
+	"version": "0.2.0",
 	"author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
 	"description": "Retrieve object list entries in S3 using minimatch-style globbing.",
 	"keywords": [ "s3", "glob" ],
@@ -18,23 +18,23 @@
 		"coverage": "istanbul check-coverage --statement 100 --branch 100 --function 100"
 	},
 	"dependencies": {
-		"lodash": "*",
-		"minimatch": "*"
-	},
-	"peerDependencies": {
-		"aws-sdk": "*"
+		"lodash": "^3.1.0",
+		"aws-sdk": "^2.1.8",
+		"minimatch": "^1.0.0",
+		"s3-url": "^0.2.2"
 	},
 	"devDependencies": {
-		"eslint": "*",
-		"eslint-plugin-nodeca": "*",
-		"mocha": "*",
-		"istanbul": "*",
-		"chai": "*",
-		"chai-things": "*",
-		"sinon": "*",
-		"sinon-chai": "*"
+		"eslint": "^0.14.0",
+		"eslint-plugin-nodeca": "^1.0.3",
+		"mocha": "^2.1.0",
+		"istanbul": "^0.3.5",
+		"chai": "^1.10.0",
+		"chai-things": "^0.2.0",
+		"sinon": "^1.12.2",
+		"sinon-chai": "^2.6.0"
 	},
 	"engines" : {
-		"node" : ">=0.10"
+		"node" : "^0.10 || ^0.12",
+		"iojs": "^1.0.0"
 	}
 }


### PR DESCRIPTION
The globs can now be passed in as URLs instead of simple strings. Several updates to dependencies, documentation and tests. Old code is likely compatible, but not a priority.
