### PR TITLE
use s3 request emitter to handle paging

### DIFF
--- a/lib/glob.js
+++ b/lib/glob.js
@@ -229,11 +229,6 @@ GlobStream.prototype._read = function _read(size) {
 		return;
 	}
 
-	// No work needs doing if we're not reading anything.
-	if (size <= 0) {
-		return;
-	}
-
 	self._reading = true;
 
 	var request = _.defaults({ }, {
@@ -244,37 +239,26 @@ GlobStream.prototype._read = function _read(size) {
 
 	// Fetch the objects making sure to respect the desired
 	// highWaterMark (passed in through size here).
-	self.s3.listObjects(request, function listObjectsDone(err, result) {
+	self.s3.listObjects(request)
+		.on('error', function (error) {
+			self.emit('errror', error);
+		})
+		.on('success', function handleResult(result) {
+			_.forEach(result.data.Contents, function (entry) {
+				entry.Bucket = request.Bucket;
+				self.process(state, entry);
+			});
 
-		// Pass thru errors
-		if (err) {
-			return self.emit('error', err);
-		}
-
-		// Pump all the matching results out to the stream
-		_.forEach(result.Contents, function process(entry) {
-			entry.Bucket = request.Bucket;
-			self.process(state, entry);
-		});
-
-		// Unlock for more reads
-		self._reading = false;
-
-		// Upload local state if necessary; if the results are truncated then
-		// more results are available for the current state, so just update the
-		// marker; otherwise the state is done and we can pop it off the list
-		// of states to process.
-		if (result.IsTruncated) {
-			// The NextMarker is only provided when Delimiter is set, otherwise
-			// the Key of the last element is to be used instead (as per the
-			// AWS documentation).
-			state.marker = result.NextMarker || _.last(result.Contents).Key;
-		} else {
-			self.states.pop();
-		}
-
-		self._read(size - result.Contents.length);
-	});
+			if (result.hasNextPage()) {
+				result.nextPage().on('success', handleResult).send();
+			} else {
+				// Unlock for more reads
+				self._reading = false;
+				self.states.pop();
+				self._read(size);
+			}
+		})
+		.send();
 };
 
 module.exports = GlobStream;

--- a/package.json
+++ b/package.json
@@ -1,40 +1,43 @@
 {
-	"name": "s3-glob",
-	"version": "0.2.0",
-	"author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
-	"description": "Retrieve object list entries in S3 using minimatch-style globbing.",
-	"keywords": [ "s3", "glob" ],
-	"license": "CC0-1.0",
-	"homepage": "https://github.com/izaakschroeder/s3-glob",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/izaakschroeder/s3-glob.git"
-	},
-	"main": "lib/glob.js",
-	"scripts": {
-		"test": "npm run lint && npm run spec && npm run coverage",
-		"spec": "NODE_PATH=lib NODE_ENV=test istanbul cover node_modules/.bin/_mocha -- -r test/helpers/chai -r test/helpers/sinon -R spec test/spec",
-		"lint": "eslint --ignore-path .gitignore .",
-		"coverage": "istanbul check-coverage --statement 100 --branch 100 --function 100"
-	},
-	"dependencies": {
-		"lodash": "^3.1.0",
-		"aws-sdk": "^2.1.8",
-		"minimatch": "^1.0.0",
-		"s3-url": "^0.2.2"
-	},
-	"devDependencies": {
-		"eslint": "^0.14.0",
-		"eslint-plugin-nodeca": "^1.0.3",
-		"mocha": "^2.1.0",
-		"istanbul": "^0.3.5",
-		"chai": "^1.10.0",
-		"chai-things": "^0.2.0",
-		"sinon": "^1.12.2",
-		"sinon-chai": "^2.6.0"
-	},
-	"engines" : {
-		"node" : "^0.10 || ^0.12",
-		"iojs": "^1.0.0"
-	}
+  "name": "s3-glob",
+  "version": "0.2.0",
+  "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
+  "description": "Retrieve object list entries in S3 using minimatch-style globbing.",
+  "keywords": [
+    "s3",
+    "glob"
+  ],
+  "license": "CC0-1.0",
+  "homepage": "https://github.com/izaakschroeder/s3-glob",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/izaakschroeder/s3-glob.git"
+  },
+  "main": "lib/glob.js",
+  "scripts": {
+    "test": "npm run lint && npm run spec && npm run coverage",
+    "spec": "NODE_PATH=lib NODE_ENV=test istanbul cover node_modules/.bin/_mocha -- -r test/helpers/chai -r test/helpers/sinon -R spec test/spec",
+    "lint": "eslint --ignore-path .gitignore .",
+    "coverage": "istanbul check-coverage --statement 100 --branch 100 --function 100"
+  },
+  "dependencies": {
+    "aws-sdk": "^2.2.43",
+    "lodash": "^3.1.0",
+    "minimatch": "^1.0.0",
+    "s3-url": "^0.2.2"
+  },
+  "devDependencies": {
+    "eslint": "^0.14.0",
+    "eslint-plugin-nodeca": "^1.0.3",
+    "mocha": "^2.1.0",
+    "istanbul": "^0.3.5",
+    "chai": "^1.10.0",
+    "chai-things": "^0.2.0",
+    "sinon": "^1.12.2",
+    "sinon-chai": "^2.6.0"
+  },
+  "engines": {
+    "node": "^0.10 || ^0.12",
+    "iojs": "^1.0.0"
+  }
 }


### PR DESCRIPTION
I ran into an issue where s3-glob (via vinyl-s3) was never emitting 'end' if the number of objects to list was higher than the highWaterMark. Digging into the code, I think we can handle truncating / paging results more simply by leveraging AWS' [Request objects & `nextPage`](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-making-requests.html#The_nextPage_and_hasNextPage_methods). 

Tests are broken right now, just wanted to surface this for :eyes: on the concept.
